### PR TITLE
[정진관]Create : users.views.SigninView

### DIFF
--- a/core/social_apis.py
+++ b/core/social_apis.py
@@ -1,0 +1,21 @@
+import requests
+
+class Kakao_Token_Error(Exception):
+    def __init__(self):
+        self.message = 'Invalid Token'
+
+class KakaoAPI:
+    def __init__(self, access_token):
+        self.access_token = access_token
+        self.user_url     = "https://kapi.kakao.com/v2/user/me"
+
+    def get_kakao_user_information(self):
+        headers = {"Authorization": f"Bearer {self.access_token}"}
+
+        response = requests.get(self.user_url, headers = headers, timeout = 3)
+        
+        if not response.status_code == 200:
+            raise Kakao_Token_Error
+	
+        return response.json()
+

--- a/faketrip/settings.py
+++ b/faketrip/settings.py
@@ -14,7 +14,7 @@ import pymysql
 
 from pathlib import Path
 
-from my_settings import DATABASES, SECRET_KEY
+from my_settings import DATABASES, SECRET_KEY, ALGORITHM
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -45,7 +45,7 @@ INSTALLED_APPS = [
     'corsheaders',
     'users',
     'products',
-    'orders'
+    'orders',
 ]
 
 MIDDLEWARE = [
@@ -153,3 +153,5 @@ CORS_ALLOW_HEADERS = (
 APPEND_SLASH = False
 
 pymysql.install_as_MySQLdb()
+
+ALGORITHM = ALGORITHM

--- a/faketrip/urls.py
+++ b/faketrip/urls.py
@@ -13,7 +13,8 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
-from django.urls import path
+from django.urls import path, include
 
 urlpatterns = [
+    path('users', include('users.urls'))
 ]

--- a/users/tests.py
+++ b/users/tests.py
@@ -1,3 +1,121 @@
-from django.test import TestCase
+import jwt
 
-# Create your tests here.
+from unittest.mock import patch, MagicMock
+from django.test   import TestCase, Client
+
+from .models           import User
+from faketrip.settings import SECRET_KEY, ALGORITHM
+
+class SinginTest(TestCase):
+    def setUp(self):
+        User.objects.create(
+            id       = 1,
+            kakao_pk = 151512,
+            email    = 'qwer123@nate.com',
+            name     = '위코드'
+        )
+
+    def tearDown(self):
+        User.objects.all().delete()
+
+    @patch("core.social_apis.requests")
+    def test_success_kakao_signin(self, mocked_requests):
+        client = Client()
+
+        class MockedResponse:
+            def json(self):
+                return {
+                    'id': 151512, 
+                    'connected_at': '2022-07-06T16:22:22Z', 
+                    'properties': {
+                        'nickname': '위코드', 
+                        'profile_image': 'http://가짜.이미지.jpg', 
+                        'thumbnail_image': 'http://가짜.이미지2.jpg'
+                        }, 
+                    'kakao_account': {
+                        'profile_nickname_needs_agreement': False, 
+                        'profile_image_needs_agreement': False, 
+                        'profile': {
+                            'nickname': '위코드', 
+                            'thumbnail_image_url': 'http://가짜.이미지2.jpg', 
+                            'profile_image_url': 'http://가짜.이미지.jpg', 
+                            'is_default_image': False}, 
+                            'has_email': True, 
+                            'email_needs_agreement': False, 
+                            'is_email_valid': True, 
+                            'is_email_verified': True, 
+                            'email': 'qwer123@nate.com'}}
+
+            status_code = 200
+    
+        mocked_requests.get = MagicMock(return_value = MockedResponse())
+        headers             = {'HTTP_token' : '가짜 access_token'}
+        response            = client.get('/users/signin', **headers)
+        user                = User.objects.get(id = 1)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers.get('Authorization'),
+            jwt.encode({'user_id' : user.id}, SECRET_KEY, ALGORITHM)
+        )
+        self.assertEqual(response.json()['message'], 'SUCCESS')
+        
+    @patch('core.social_apis.requests')
+    def test_success_changed_kakao_information_user_signin(self, mocked_requests):
+        client = Client()
+
+        class MockedResponse:
+            def json(self):
+                return {
+                    'id': 151512, 
+                    'connected_at': '2022-07-06T16:22:22Z', 
+                    'properties': {
+                        'nickname': '코드', 
+                        'profile_image': 'http://가짜.이미지.jpg', 
+                        'thumbnail_image': 'http://가짜.이미지2.jpg'
+                        }, 
+                    'kakao_account': {
+                        'profile_nickname_needs_agreement': False, 
+                        'profile_image_needs_agreement': False, 
+                        'profile': {
+                            'nickname': '위코드', 
+                            'thumbnail_image_url': 'http://가짜.이미지2.jpg', 
+                            'profile_image_url': 'http://가짜.이미지.jpg', 
+                            'is_default_image': False}, 
+                            'has_email': True, 
+                            'email_needs_agreement': False, 
+                            'is_email_valid': True, 
+                            'is_email_verified': True, 
+                            'email': 'qwer@nate.com'}}
+    
+            status_code = 200
+        
+        mocked_requests.get = MagicMock(return_value = MockedResponse())
+        headers             = {'HTTP_token' : '가짜 access_token'}
+        response            = client.get('/users/signin', **headers)
+        user                = User.objects.get(id = 1)
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.headers.get('Authorization'),
+            jwt.encode({'user_id' : user.id}, SECRET_KEY, ALGORITHM)
+        )
+        self.assertEqual(response.json()['message'], 'SUCCESS')
+        self.assertEqual(user.name, '코드')
+        self.assertEqual(user.email, 'qwer@nate.com')
+
+    @patch("core.social_apis.requests")
+    def test_fail_kakao_signin(self, mocked_requests):
+        client = Client()
+
+        class MockedResponse:
+            def json(self):
+                return {'msg': 'this access token does not exist', 'code': -401}
+                
+            status_code = 401
+    
+        mocked_requests.get = MagicMock(return_value = MockedResponse())
+        headers             = {'HTTP_token' : '가짜 access_token'}
+        response            = client.get('/users/signin', **headers)
+
+        self.assertEqual(response.status_code, 401)
+        self.assertEqual(response.headers.get('Authorization'),None)
+        self.assertEqual(response.json()['message'], 'Invalid Token')

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+
+from users.views import SigninView
+urlpatterns = [
+    path('/signin', SigninView.as_view())
+]

--- a/users/views.py
+++ b/users/views.py
@@ -1,3 +1,33 @@
-from django.shortcuts import render
+import requests
 
-# Create your views here.
+import jwt
+
+from django.views import View
+from django.http  import JsonResponse
+
+from users.models      import User
+from faketrip.settings import SECRET_KEY, ALGORITHM
+from core.social_apis  import Kakao_Token_Error, KakaoAPI
+
+class SigninView(View):
+    def get(self, request):
+        try:
+            access_token     = request.headers.get('Authorization')
+            user_information = KakaoAPI(access_token).get_kakao_user_information()
+            
+            kakao_pk = user_information.get('id')
+            email    = user_information.get('kakao_account').get('email')
+            nickname = user_information.get('properties').get('nickname')
+
+            user, created = User.objects.get_or_create(kakao_pk=kakao_pk, default = {"email" : email, "name" : nickname})
+            
+            if not created and not(user.email == email and user.name == nickname):
+                user.email, user.name = email, nickname
+                user.save()
+
+            authorization = jwt.encode({'user_id' : user.id}, SECRET_KEY, ALGORITHM)
+
+            return JsonResponse({'message' : 'SUCCESS'},headers = {'Authorization' : authorization}, status = 200)
+        
+        except Kakao_Token_Error as error:
+            return JsonResponse({'message' : error.message}, status = 401)


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ x ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 카카오 소셜 로그인 기능 추가
<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
1. 클라이언트에서 받은 토큰을 이용하여 카카오서버에서 유저의 정보를 얻었습니다.
2. 카카오서버에서 얻은 response의 body에 'code' 키가 있을시 에러 반환을 하였습니다.
3. get_or_create 를 사용하여 유저정보를 db에 저장 or 이미 있는 유저의 정보를 얻어왔습니다.
4. jwt를 사용하여 현재 서비스의 토큰을 클라이언트에게 전달하였습니다.

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
- 백엔드에서 request를 보내는 법을 배웠습니다.
- 소셜로그인 API의 flow를 배울 수 있었습니다.

<br />

## :: 기타 질문 및 특이 사항
- 카카오에서 들어온 정보를 어느정도 까지 유효성 검사를 해야하는지 궁금합니다.(중복검사, email 형식검사 등등)
- 저희 프로젝트에서는 카카오 로그인으로 인해 별도의 회원가입없이 진행됩니다.
- get_or_create 문을 통해 유저정보 저장 혹은 get을 하는데 이경우 Signup과 Signin 기능이 동시에 한 View에서 진행이되는데 View 컨벤션을 어떻게 해야할지 궁금합니다.